### PR TITLE
Added print statement

### DIFF
--- a/pyatomdb/pyatomdb/spectrum.py
+++ b/pyatomdb/pyatomdb/spectrum.py
@@ -1079,6 +1079,7 @@ def print_lines(llist, specunits = 'A', do_cfg=False):
                                  lvdat[1].data['LEV_DEG'][il['LowerLev']-1])
       else:
         pass
+      print(s)
 
 
 


### PR DESCRIPTION
There was a missing print statement in one of the `if` statements in `spectrum.print_lines`

Now it prints for the example case shown in http://atomdb.readthedocs.io/en/master/index.html
